### PR TITLE
Removed workaround for https warning in IE6/7

### DIFF
--- a/js/tinymce/classes/Editor.js
+++ b/js/tinymce/classes/Editor.js
@@ -707,7 +707,7 @@ define("tinymce/Editor", [
 				self.fire("load");
 			};
 
-			DOM.setAttrib(ifr, "src", url || 'javascript:""');
+			DOM.setAttrib(ifr, "src", url);
 
 			self.contentAreaContainer = o.iframeContainer;
 			self.iframeElement = ifr;


### PR DESCRIPTION
Removed the workaround for a https warning in ie6/7 because url is always falsy if your on the same domain. Which leads to a CSP unsafe-inline error.